### PR TITLE
v1.2.5

### DIFF
--- a/.agents/skills/goat-critique/SKILL.md
+++ b/.agents/skills/goat-critique/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-critique
 description: "Use when a decision or analysis needs multi-lens critique to surface blind spots before shipping."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-critique
 

--- a/.agents/skills/goat-debug/SKILL.md
+++ b/.agents/skills/goat-debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-debug
 description: "Use when diagnosing a bug, unexpected behaviour, or system failure that needs structured investigation."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-debug
 

--- a/.agents/skills/goat-plan/SKILL.md
+++ b/.agents/skills/goat-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-plan
 description: "Use when starting a non-trivial implementation that needs structured task breakdown with progress tracking."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-plan
 

--- a/.agents/skills/goat-qa/SKILL.md
+++ b/.agents/skills/goat-qa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-qa
 description: "Use when evaluating test coverage gaps, planning test strategy, or assessing testing risk for code changes."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-qa
 

--- a/.agents/skills/goat-review/SKILL.md
+++ b/.agents/skills/goat-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-review
 description: "Use when reviewing a diff, PR, or set of code changes, or auditing a codebase area for quality issues. Triggers: 'review this', 'code review', 'audit X', 'look at these changes'."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-review
 

--- a/.agents/skills/goat-security/SKILL.md
+++ b/.agents/skills/goat-security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-security
 description: "Use when assessing security implications of code changes, architecture decisions, or new features."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-security
 

--- a/.agents/skills/goat/SKILL.md
+++ b/.agents/skills/goat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat
 description: "Use when you describe an outcome and need the right goat-* workflow chosen for you."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat
 

--- a/.claude/hooks/deny-dangerous.sh
+++ b/.claude/hooks/deny-dangerous.sh
@@ -318,6 +318,11 @@ run_self_test() {
   run_case "cat quoted home env" "$(printf 'cat \"$HOME/.env\"')" 2
   # shellcheck disable=SC2016
   run_case "cat quoted gcloud adc" "$(printf 'cat \"$HOME/.config/gcloud/application_default_credentials.json\"')" 2
+  # npm token delete/revoke must block; safe npm commands must pass.
+  run_case "npm token delete" "npm token delete abc123" 2
+  run_case "npm token revoke" "npm token revoke abc123" 2
+  run_case "npm token list" "npm token list" 0
+  run_case "npm install" "npm install lodash" 0
   # Code-search for env-related strings must still pass (no .env path touch).
   run_case "grep env src" "grep env src/" 0
   run_case "rg dotenv" "rg dotenv src/" 0
@@ -674,6 +679,11 @@ check_segment() {
   # 16. Destructive database commands via CLI tools
   if [[ "$cmd_lower" =~ (mysql|psql|sqlite3|mongosh)[[:space:]].*(-e|--command|--eval)[[:space:]]+.*(drop[[:space:]]+(database|table|schema)|truncate[[:space:]]+table) ]]; then
     block "Destructive database command (DROP/TRUNCATE). Run manually with verification."
+  fi
+
+  # 17. npm token delete/revoke (irreversible credential destruction)
+  if [[ "$cmd_lower" =~ npm[[:space:]]+token[[:space:]]+(delete|revoke) ]]; then
+    block "npm token delete/revoke is irreversible. Manage tokens manually via the npm website."
   fi
 
   # --- CUSTOMIZE: Add project-specific blocks below --------------------------

--- a/.claude/skills/goat-critique/SKILL.md
+++ b/.claude/skills/goat-critique/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-critique
 description: "Use when a decision or analysis needs multi-lens critique to surface blind spots before shipping."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-critique
 

--- a/.claude/skills/goat-debug/SKILL.md
+++ b/.claude/skills/goat-debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-debug
 description: "Use when diagnosing a bug, unexpected behaviour, or system failure that needs structured investigation."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-debug
 

--- a/.claude/skills/goat-plan/SKILL.md
+++ b/.claude/skills/goat-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-plan
 description: "Use when starting a non-trivial implementation that needs structured task breakdown with progress tracking."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-plan
 

--- a/.claude/skills/goat-qa/SKILL.md
+++ b/.claude/skills/goat-qa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-qa
 description: "Use when evaluating test coverage gaps, planning test strategy, or assessing testing risk for code changes."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-qa
 

--- a/.claude/skills/goat-review/SKILL.md
+++ b/.claude/skills/goat-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-review
 description: "Use when reviewing a diff, PR, or set of code changes, or auditing a codebase area for quality issues. Triggers: 'review this', 'code review', 'audit X', 'look at these changes'."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-review
 

--- a/.claude/skills/goat-security/SKILL.md
+++ b/.claude/skills/goat-security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-security
 description: "Use when assessing security implications of code changes, architecture decisions, or new features."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-security
 

--- a/.claude/skills/goat/SKILL.md
+++ b/.claude/skills/goat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat
 description: "Use when you describe an outcome and need the right goat-* workflow chosen for you."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat
 

--- a/.codex/hooks/deny-dangerous.sh
+++ b/.codex/hooks/deny-dangerous.sh
@@ -318,6 +318,11 @@ run_self_test() {
   run_case "cat quoted home env" "$(printf 'cat \"$HOME/.env\"')" 2
   # shellcheck disable=SC2016
   run_case "cat quoted gcloud adc" "$(printf 'cat \"$HOME/.config/gcloud/application_default_credentials.json\"')" 2
+  # npm token delete/revoke must block; safe npm commands must pass.
+  run_case "npm token delete" "npm token delete abc123" 2
+  run_case "npm token revoke" "npm token revoke abc123" 2
+  run_case "npm token list" "npm token list" 0
+  run_case "npm install" "npm install lodash" 0
   # Code-search for env-related strings must still pass (no .env path touch).
   run_case "grep env src" "grep env src/" 0
   run_case "rg dotenv" "rg dotenv src/" 0
@@ -674,6 +679,11 @@ check_segment() {
   # 16. Destructive database commands via CLI tools
   if [[ "$cmd_lower" =~ (mysql|psql|sqlite3|mongosh)[[:space:]].*(-e|--command|--eval)[[:space:]]+.*(drop[[:space:]]+(database|table|schema)|truncate[[:space:]]+table) ]]; then
     block "Destructive database command (DROP/TRUNCATE). Run manually with verification."
+  fi
+
+  # 17. npm token delete/revoke (irreversible credential destruction)
+  if [[ "$cmd_lower" =~ npm[[:space:]]+token[[:space:]]+(delete|revoke) ]]; then
+    block "npm token delete/revoke is irreversible. Manage tokens manually via the npm website."
   fi
 
   # --- CUSTOMIZE: Add project-specific blocks below --------------------------

--- a/.gemini/hooks/deny-dangerous.sh
+++ b/.gemini/hooks/deny-dangerous.sh
@@ -318,6 +318,11 @@ run_self_test() {
   run_case "cat quoted home env" "$(printf 'cat \"$HOME/.env\"')" 2
   # shellcheck disable=SC2016
   run_case "cat quoted gcloud adc" "$(printf 'cat \"$HOME/.config/gcloud/application_default_credentials.json\"')" 2
+  # npm token delete/revoke must block; safe npm commands must pass.
+  run_case "npm token delete" "npm token delete abc123" 2
+  run_case "npm token revoke" "npm token revoke abc123" 2
+  run_case "npm token list" "npm token list" 0
+  run_case "npm install" "npm install lodash" 0
   # Code-search for env-related strings must still pass (no .env path touch).
   run_case "grep env src" "grep env src/" 0
   run_case "rg dotenv" "rg dotenv src/" 0
@@ -674,6 +679,11 @@ check_segment() {
   # 16. Destructive database commands via CLI tools
   if [[ "$cmd_lower" =~ (mysql|psql|sqlite3|mongosh)[[:space:]].*(-e|--command|--eval)[[:space:]]+.*(drop[[:space:]]+(database|table|schema)|truncate[[:space:]]+table) ]]; then
     block "Destructive database command (DROP/TRUNCATE). Run manually with verification."
+  fi
+
+  # 17. npm token delete/revoke (irreversible credential destruction)
+  if [[ "$cmd_lower" =~ npm[[:space:]]+token[[:space:]]+(delete|revoke) ]]; then
+    block "npm token delete/revoke is irreversible. Manage tokens manually via the npm website."
   fi
 
   # --- CUSTOMIZE: Add project-specific blocks below --------------------------

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions - v1.2.4 (2026-04-23)
+# Copilot Instructions - v1.2.5 (2026-04-23)
 Documentation framework for AI coding agent workflows. Markdown docs + Bash scripts + TypeScript CLI auditor.
 ## Essential Commands
 

--- a/.github/hooks/deny-dangerous.sh
+++ b/.github/hooks/deny-dangerous.sh
@@ -318,6 +318,11 @@ run_self_test() {
   run_case "cat quoted home env" "$(printf 'cat \"$HOME/.env\"')" 2
   # shellcheck disable=SC2016
   run_case "cat quoted gcloud adc" "$(printf 'cat \"$HOME/.config/gcloud/application_default_credentials.json\"')" 2
+  # npm token delete/revoke must block; safe npm commands must pass.
+  run_case "npm token delete" "npm token delete abc123" 2
+  run_case "npm token revoke" "npm token revoke abc123" 2
+  run_case "npm token list" "npm token list" 0
+  run_case "npm install" "npm install lodash" 0
   # Code-search for env-related strings must still pass (no .env path touch).
   run_case "grep env src" "grep env src/" 0
   run_case "rg dotenv" "rg dotenv src/" 0
@@ -674,6 +679,11 @@ check_segment() {
   # 16. Destructive database commands via CLI tools
   if [[ "$cmd_lower" =~ (mysql|psql|sqlite3|mongosh)[[:space:]].*(-e|--command|--eval)[[:space:]]+.*(drop[[:space:]]+(database|table|schema)|truncate[[:space:]]+table) ]]; then
     block "Destructive database command (DROP/TRUNCATE). Run manually with verification."
+  fi
+
+  # 17. npm token delete/revoke (irreversible credential destruction)
+  if [[ "$cmd_lower" =~ npm[[:space:]]+token[[:space:]]+(delete|revoke) ]]; then
+    block "npm token delete/revoke is irreversible. Manage tokens manually via the npm website."
   fi
 
   # --- CUSTOMIZE: Add project-specific blocks below --------------------------

--- a/.github/skills/goat-critique/SKILL.md
+++ b/.github/skills/goat-critique/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-critique
 description: "Use when a decision or analysis needs multi-lens critique to surface blind spots before shipping."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-critique
 

--- a/.github/skills/goat-debug/SKILL.md
+++ b/.github/skills/goat-debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-debug
 description: "Use when diagnosing a bug, unexpected behaviour, or system failure that needs structured investigation."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-debug
 

--- a/.github/skills/goat-plan/SKILL.md
+++ b/.github/skills/goat-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-plan
 description: "Use when starting a non-trivial implementation that needs structured task breakdown with progress tracking."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-plan
 

--- a/.github/skills/goat-qa/SKILL.md
+++ b/.github/skills/goat-qa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-qa
 description: "Use when evaluating test coverage gaps, planning test strategy, or assessing testing risk for code changes."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-qa
 

--- a/.github/skills/goat-review/SKILL.md
+++ b/.github/skills/goat-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-review
 description: "Use when reviewing a diff, PR, or set of code changes, or auditing a codebase area for quality issues. Triggers: 'review this', 'code review', 'audit X', 'look at these changes'."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-review
 

--- a/.github/skills/goat-security/SKILL.md
+++ b/.github/skills/goat-security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-security
 description: "Use when assessing security implications of code changes, architecture decisions, or new features."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-security
 

--- a/.github/skills/goat/SKILL.md
+++ b/.github/skills/goat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat
 description: "Use when you describe an outcome and need the right goat-* workflow chosen for you."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat
 

--- a/.goat-flow/config.yaml
+++ b/.goat-flow/config.yaml
@@ -1,7 +1,7 @@
 # .goat-flow/config.yaml - project configuration
 # Docs: https://github.com/blundergoat/goat-flow
 
-version: "1.2.4"
+version: "1.2.5"
 
 # ── Project Setup ───────────────────────────────
 agents:

--- a/.goat-flow/footguns/cli.md
+++ b/.goat-flow/footguns/cli.md
@@ -1,0 +1,24 @@
+---
+category: cli
+last_reviewed: 2026-04-24
+---
+
+## Footgun: ESM main-module guard breaks under symlinks
+
+**Status:** active | **Created:** 2026-04-24 | **Evidence:** ACTUAL_MEASURED
+
+`path.resolve()` does not follow symlinks, but Node's ESM loader resolves symlinks for `import.meta.url` by default (via `--preserve-symlinks-main=false`). Any main-module guard that compares `resolve(process.argv[1])` against `fileURLToPath(import.meta.url)` silently fails when the script is invoked through a symlink — which is always the case for npm-installed CLIs, because `node_modules/.bin/<name>` is a symlink to the package's bin entry.
+
+**Symptoms:** CLI exits 0 with zero output. No error, no stderr. Downstream scripts that spawn the CLI see the child die immediately with no diagnostic. Only direct invocation via `node dist/cli/cli.js` works.
+
+**Why it happens:** npm creates `node_modules/.bin/goat-flow` → `../@blundergoat/goat-flow/dist/cli/cli.js`. When the shell launches the symlink via shebang, `process.argv[1]` is the symlink path. `resolve()` normalizes it but does not follow the symlink. Meanwhile `import.meta.url` points at the real file because Node's ESM loader follows symlinks by default. The two paths differ, the guard evaluates false, and `main()` never runs.
+
+**Evidence:**
+- `src/cli/cli.ts` (search: `isMainModule`) — the fixed guard uses `realpathSync()` on both sides to normalize through symlinks.
+- `test/integration/main-guard.test.ts` (search: `launched through a symlink`) — regression test that creates a temp-dir symlink and verifies the CLI produces output.
+- Commit 918ca3e introduced the broken guard; the fix adds `realpathSync` to resolve both paths canonically before comparison.
+
+**Prevention:**
+1. Never compare `resolve(process.argv[1])` directly to `fileURLToPath(import.meta.url)`. Always wrap both sides in `realpathSync()`.
+2. `test/integration/main-guard.test.ts` locks this in — any future change to the entry-point guard must pass the symlink test.
+3. When Node 24+ is the minimum, replace the entire guard with `import.meta.main`.

--- a/.goat-flow/lessons/verification.md
+++ b/.goat-flow/lessons/verification.md
@@ -625,3 +625,17 @@ last_reviewed: 2026-04-24
 **Prevention:**
 1. After any edit to `workflow/manifest.json`, immediately check whether `workflow/manifest-snapshots/v<current-version>.json` needs the same change. The current-version snapshot is a live mirror, not a historical record.
 2. When grepping for stale references, do not dismiss snapshot hits without checking the version number. Only snapshots for OLDER versions are frozen history.
+
+---
+
+## Lesson: Test suite must exercise the published invocation path
+
+**Status:** active | **Created:** 2026-04-24
+
+**What happened:** Commit 918ca3e wrapped the bare `main().catch(...)` call in an `import.meta.url` guard to prevent side effects on import. The guard used `resolve(process.argv[1]) === fileURLToPath(import.meta.url)`, which silently fails when the CLI is invoked through a symlink (the standard npm/npx path). All 359 tests passed because every test imports CLI functions directly or shells out via `node dist/cli/cli.js` — no test invoked the binary through a symlink, which is how every real consumer runs it.
+
+**Root cause:** The test suite verified internal function behavior but never exercised the actual entry-point guard through the `.bin/` symlink path that `npx` uses. The refactor commit was titled "update goat-critique documentation," making it easy to overlook a CLI entry-point change during review.
+
+**Prevention:**
+1. `test/integration/main-guard.test.ts` now tests the CLI via a temp-dir symlink — the exact path that broke. This test would have caught the regression.
+2. When modifying the entry-point guard or anything that controls whether `main()` runs, verify via symlink invocation, not just direct `node dist/cli/cli.js`.

--- a/.goat-flow/skill-reference/skill-quality-testing/deployment.md
+++ b/.goat-flow/skill-reference/skill-quality-testing/deployment.md
@@ -37,7 +37,7 @@ Every skill MUST pass this checklist before merging. Track each item as a todo i
 
 **GREEN phase - write minimal skill:**
 - [ ] Name describes what you DO or the core insight
-- [ ] Frontmatter has `goat-flow-skill-version: "1.2.4"` and trigger-only `description`
+- [ ] Frontmatter has `goat-flow-skill-version: "1.2.5"` and trigger-only `description`
 - [ ] `description` is CSO-optimised: "Use when [trigger]", not a workflow summary
 - [ ] Keywords throughout for search (error messages, symptoms, tool names)
 - [ ] Overview states the core principle in 1–2 sentences

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md - v1.2.4 (2026-04-23)
+# AGENTS.md - v1.2.5 (2026-04-23)
 Documentation framework for AI coding agent workflows. Markdown docs + Bash validation scripts + TypeScript CLI/dashboard.
 ## Essential Commands
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.2.5 - 2026-04-24
+
+CLI silently exited without running when invoked through a symlink — which is every `npx goat-flow`, `./node_modules/.bin/goat-flow`, and npm `scripts` invocation. Fixed the main-module guard and added a regression test.
+
+- **fix: CLI no-op via symlink** - The ESM main-module guard compared `resolve(process.argv[1])` against `fileURLToPath(import.meta.url)`. `path.resolve()` does not follow symlinks, but Node's ESM loader resolves symlinks for `import.meta.url` by default. When the CLI was launched through the `node_modules/.bin/goat-flow` symlink (the standard npm/npx path), the two sides never matched, `main()` never ran, and the process exited 0 with zero output. The fix wraps both sides in `fs.realpathSync()` via an `isMainModule()` helper, with a try/catch for synthetic `argv[1]` values. Introduced in 918ca3e (v1.2.4).
+- **regression test** - `test/integration/main-guard.test.ts` creates a temp-dir symlink to `dist/cli/cli.js` and verifies `--version` produces output through both the symlink and the real path. This is the exact invocation path that broke.
+- **footgun** - New `.goat-flow/footguns/cli.md`: "ESM main-module guard breaks under symlinks" documents the structural trap and prevention rules.
+- **lesson** - `.goat-flow/lessons/verification.md`: "Test suite must exercise the published invocation path" — all 359 tests passed while the CLI was broken for every real consumer, because no test went through the `.bin/` symlink.
+
 ## v1.2.4 - 2026-04-23
 
 Quality report fixes, node-pty as optional dependency, configurable terminal timeout, dashboard settings/export, QA prompt improvements, preset prompt library expansion, ADR-024 semantic anchors, manifest snapshot backfill, and lesson line-ref validation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - v1.2.4 (2026-04-23)
+# CLAUDE.md - v1.2.5 (2026-04-23)
 Documentation framework for AI coding agent workflows. Markdown docs + Bash scripts + TypeScript CLI auditor.
 ## Essential Commands
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,4 @@
-# GEMINI.md - v1.2.4 (2026-04-23)
+# GEMINI.md - v1.2.5 (2026-04-23)
 Documentation framework for AI coding agent workflows. Markdown docs + Bash validation scripts + TypeScript CLI/dashboard.
 ## Essential Commands
 

--- a/docs/audit-and-quality.md
+++ b/docs/audit-and-quality.md
@@ -74,7 +74,7 @@ Sample harness output:
 ```
 GOAT Flow Setup:          PASS
   Skills:                 7/7 installed
-  Config:                 valid, version 1.2.4
+  Config:                 valid, version 1.2.5
   InstructionFile:        118 lines
 
 Agent Setup:              PASS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blundergoat/goat-flow",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blundergoat/goat-flow",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blundergoat/goat-flow",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "CLI auditor, dashboard, and setup generator for GOAT Flow AI coding agent workflows",
   "author": {
     "name": "Matthew Hansen",

--- a/scripts/deny-dangerous.sh
+++ b/scripts/deny-dangerous.sh
@@ -318,6 +318,11 @@ run_self_test() {
   run_case "cat quoted home env" "$(printf 'cat \"$HOME/.env\"')" 2
   # shellcheck disable=SC2016
   run_case "cat quoted gcloud adc" "$(printf 'cat \"$HOME/.config/gcloud/application_default_credentials.json\"')" 2
+  # npm token delete/revoke must block; safe npm commands must pass.
+  run_case "npm token delete" "npm token delete abc123" 2
+  run_case "npm token revoke" "npm token revoke abc123" 2
+  run_case "npm token list" "npm token list" 0
+  run_case "npm install" "npm install lodash" 0
   # Code-search for env-related strings must still pass (no .env path touch).
   run_case "grep env src" "grep env src/" 0
   run_case "rg dotenv" "rg dotenv src/" 0
@@ -674,6 +679,11 @@ check_segment() {
   # 16. Destructive database commands via CLI tools
   if [[ "$cmd_lower" =~ (mysql|psql|sqlite3|mongosh)[[:space:]].*(-e|--command|--eval)[[:space:]]+.*(drop[[:space:]]+(database|table|schema)|truncate[[:space:]]+table) ]]; then
     block "Destructive database command (DROP/TRUNCATE). Run manually with verification."
+  fi
+
+  # 17. npm token delete/revoke (irreversible credential destruction)
+  if [[ "$cmd_lower" =~ npm[[:space:]]+token[[:space:]]+(delete|revoke) ]]; then
+    block "npm token delete/revoke is irreversible. Manage tokens manually via the npm website."
   fi
 
   # --- CUSTOMIZE: Add project-specific blocks below --------------------------

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -8,7 +8,7 @@
 import { parseArgs } from "node:util";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, realpathSync } from "node:fs";
 import type { CLIOptions, AgentId, ProjectFacts } from "./types.js";
 import type { AuditReport } from "./audit/types.js";
 
@@ -801,10 +801,22 @@ async function main(): Promise<void> {
   await dispatchCommand(options);
 }
 
-if (
-  process.argv[1] &&
-  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
-) {
+/** True when this module is the CLI entry point, including when launched
+ *  through a symlink like `node_modules/.bin/goat-flow`. */
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return (
+      realpathSync(resolve(entry)) ===
+      realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
   main().catch((err: unknown) => {
     if (err instanceof CLIError) {
       console.error(err.message);

--- a/test/fixtures/skill-with-references/SKILL.md
+++ b/test/fixtures/skill-with-references/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-with-references
 description: "Fixture skill used by reference-plumbing tests."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # skill-with-references
 

--- a/test/integration/main-guard.test.ts
+++ b/test/integration/main-guard.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import {
-  chmodSync,
-  mkdtempSync,
-  rmSync,
-  symlinkSync,
-} from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/test/integration/main-guard.test.ts
+++ b/test/integration/main-guard.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const REAL_CLI = join(PROJECT_ROOT, "dist", "cli", "cli.js");
+
+describe("main-module guard via symlink", () => {
+  let dir: string;
+
+  after(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("CLI runs when launched through a symlink", () => {
+    dir = mkdtempSync(join(tmpdir(), "gf-symlink-"));
+    const link = join(dir, "goat-flow");
+    symlinkSync(REAL_CLI, link);
+    chmodSync(REAL_CLI, 0o755);
+
+    const stdout = execFileSync(process.execPath, [link, "--version"], {
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    assert.match(stdout.trim(), /^goat-flow v\d+\.\d+\.\d+$/);
+  });
+
+  it("CLI runs when launched via the real path", () => {
+    const stdout = execFileSync(process.execPath, [REAL_CLI, "--version"], {
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    assert.match(stdout.trim(), /^goat-flow v\d+\.\d+\.\d+$/);
+  });
+});

--- a/test/integration/main-guard.test.ts
+++ b/test/integration/main-guard.test.ts
@@ -4,7 +4,6 @@ import { execFileSync } from "node:child_process";
 import { chmodSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
 const REAL_CLI = join(PROJECT_ROOT, "dist", "cli", "cli.js");

--- a/test/unit/check-snapshot-claims.test.ts
+++ b/test/unit/check-snapshot-claims.test.ts
@@ -115,6 +115,20 @@ const EXPECTED_RELEASE_SNAPSHOTS = [
       presets_count: 28,
     },
   },
+  {
+    version: "1.2.5",
+    facts: {
+      skills_total: 7,
+      skills_functional_count: 6,
+      checks_setup: 13,
+      checks_agent: 4,
+      checks_build: 17,
+      checks_harness: 16,
+      checks_total: 33,
+      dashboard_views_count: 8,
+      presets_count: 28,
+    },
+  },
 ] as const;
 
 // ---------------------------------------------------------------------------

--- a/workflow/hooks/deny-dangerous.sh
+++ b/workflow/hooks/deny-dangerous.sh
@@ -318,6 +318,11 @@ run_self_test() {
   run_case "cat quoted home env" "$(printf 'cat \"$HOME/.env\"')" 2
   # shellcheck disable=SC2016
   run_case "cat quoted gcloud adc" "$(printf 'cat \"$HOME/.config/gcloud/application_default_credentials.json\"')" 2
+  # npm token delete/revoke must block; safe npm commands must pass.
+  run_case "npm token delete" "npm token delete abc123" 2
+  run_case "npm token revoke" "npm token revoke abc123" 2
+  run_case "npm token list" "npm token list" 0
+  run_case "npm install" "npm install lodash" 0
   # Code-search for env-related strings must still pass (no .env path touch).
   run_case "grep env src" "grep env src/" 0
   run_case "rg dotenv" "rg dotenv src/" 0
@@ -674,6 +679,11 @@ check_segment() {
   # 16. Destructive database commands via CLI tools
   if [[ "$cmd_lower" =~ (mysql|psql|sqlite3|mongosh)[[:space:]].*(-e|--command|--eval)[[:space:]]+.*(drop[[:space:]]+(database|table|schema)|truncate[[:space:]]+table) ]]; then
     block "Destructive database command (DROP/TRUNCATE). Run manually with verification."
+  fi
+
+  # 17. npm token delete/revoke (irreversible credential destruction)
+  if [[ "$cmd_lower" =~ npm[[:space:]]+token[[:space:]]+(delete|revoke) ]]; then
+    block "npm token delete/revoke is irreversible. Manage tokens manually via the npm website."
   fi
 
   # --- CUSTOMIZE: Add project-specific blocks below --------------------------

--- a/workflow/manifest-snapshots/README.md
+++ b/workflow/manifest-snapshots/README.md
@@ -33,11 +33,8 @@ only real edits to frozen text.
 | v1.2.1 | `v1.2.1.json` | 7 skills, 13 setup + 4 agent + 16 harness = 33 checks, 8 dashboard views, 22 presets |
 | v1.2.2 | `v1.2.2.json` | 7 skills, 13 setup + 4 agent + 16 harness = 33 checks, 8 dashboard views, 22 presets |
 | v1.2.3 | `v1.2.3.json` | 7 skills, 13 setup + 4 agent + 16 harness = 33 checks, 8 dashboard views, 23 presets |
-| v1.2.4 | `v1.2.4.json` | 7 skills, 13 setup + 4 agent + 16 harness = 33 checks, 8 dashboard views, 26 presets |
-
-`v1.2.4.json` is backfilled from release commit `f1dd77d`, which matches the
-released CHANGELOG facts before later same-version preset-catalog edits landed
-in the live tree.
+| v1.2.4 | `v1.2.4.json` | 7 skills, 13 setup + 4 agent + 16 harness = 33 checks, 8 dashboard views, 28 presets |
+| v1.2.5 | `v1.2.5.json` | 7 skills, 13 setup + 4 agent + 16 harness = 33 checks, 8 dashboard views, 28 presets |
 
 ## Adding a snapshot at release time
 

--- a/workflow/manifest-snapshots/v1.2.5.json
+++ b/workflow/manifest-snapshots/v1.2.5.json
@@ -1,7 +1,7 @@
 {
+  "_snapshot_note": "Frozen copy of workflow/manifest.json as shipped at v1.2.5 release. Immutable. The live source of truth stays at workflow/manifest.json. See workflow/manifest-snapshots/README.md for the frozen-copy contract.",
   "description": "Expected goat-flow project structure. Source of truth for setup, audit, and upgrade paths. Not a JSON Schema - this is a manifest of what should exist on disk.",
   "version": "1.2.5",
-
   "required_files": [
     ".goat-flow/.gitignore",
     ".goat-flow/config.yaml",
@@ -26,7 +26,6 @@
     ".goat-flow/glossary.md",
     ".goat-flow/patterns.md"
   ],
-
   "required_dirs": [
     ".goat-flow/decisions/",
     ".goat-flow/footguns/",
@@ -38,7 +37,6 @@
     ".goat-flow/skill-reference/",
     ".goat-flow/tasks/"
   ],
-
   "directory_purposes": {
     ".goat-flow/decisions/": "Committed ADR history. Durable architectural, product-surface, and tooling decisions with context and rationale; part of the project's persistent knowledge, not session-scoped WIP.",
     ".goat-flow/footguns/": "Committed architectural trap records. Use for codebase or system footguns that exist independent of one agent mistake; entries should carry grep-friendly file evidence and remain part of durable project knowledge.",
@@ -50,15 +48,12 @@
     ".goat-flow/skill-reference/": "Committed shared cold-path skill doctrine copied from workflow templates. Holds skill-preamble.md, skill-conventions.md, and skill-quality-testing.md (index pointing at the skill-quality-testing/ subdir with tdd-iteration.md, adversarial-framing.md, deployment.md per ADR-023); durable reference state used across sessions, not transient notes.",
     ".goat-flow/tasks/": "Local, gitignored-by-design milestone files and plan subdirs. Session-scoped coordination state; not a persistence gap. Only README.md and .gitignore are committed."
   },
-
   "optional_files": {
     "_note": "Optional files created when the project needs them, not during base setup.",
     ".cursorignore": "Excludes secret/sensitive paths from Cursor context.",
     ".geminiignore": "Excludes secret/sensitive paths from Gemini context."
   },
-
   "never_create": [],
-
   "skills": {
     "canonical": [
       "goat",
@@ -95,7 +90,6 @@
       "goat-test"
     ]
   },
-
   "agents": {
     "claude": {
       "name": "Claude Code",
@@ -115,7 +109,9 @@
         "pre_tool": "PreToolUse",
         "post_turn": "Stop"
       },
-      "hooks": ["deny-dangerous.sh"]
+      "hooks": [
+        "deny-dangerous.sh"
+      ]
     },
     "codex": {
       "name": "Codex",
@@ -134,7 +130,9 @@
         "pre_tool": "PreToolUse",
         "post_turn": null
       },
-      "hooks": ["deny-dangerous.sh"]
+      "hooks": [
+        "deny-dangerous.sh"
+      ]
     },
     "gemini": {
       "name": "Gemini CLI",
@@ -154,7 +152,9 @@
         "pre_tool": "BeforeTool",
         "post_turn": "AfterAgent"
       },
-      "hooks": ["deny-dangerous.sh"]
+      "hooks": [
+        "deny-dangerous.sh"
+      ]
     },
     "copilot": {
       "name": "Copilot CLI",
@@ -172,10 +172,12 @@
         "pre_tool": "preToolUse",
         "post_turn": null
       },
-      "hooks": ["hooks.json", "deny-dangerous.sh"]
+      "hooks": [
+        "hooks.json",
+        "deny-dangerous.sh"
+      ]
     }
   },
-
   "instruction_file": {
     "line_target": 120,
     "line_limit": 150,
@@ -188,7 +190,6 @@
     ],
     "version_header_pattern": "# {FILE} - v{VERSION} ({DATE})"
   },
-
   "facts": {
     "_note": "Static facts only. Derived facts (check counts, skill names, version, presets count) are computed by src/cli/manifest/manifest.ts at load time. `goat-flow manifest --check` validates static facts against observed state (src/dashboard/views/*.html).",
     "dashboard_views": [
@@ -201,5 +202,17 @@
       "setup",
       "workspace"
     ]
+  },
+  "snapshot_facts": {
+    "_note": "Numeric facts as shipped at v1.2.5 release. Used by CHANGELOG lint to validate claims inside the v1.2.5 section of CHANGELOG.md.",
+    "skills_total": 7,
+    "skills_functional_count": 6,
+    "checks_setup": 13,
+    "checks_agent": 4,
+    "checks_build": 17,
+    "checks_harness": 16,
+    "checks_total": 33,
+    "dashboard_views_count": 8,
+    "presets_count": 28
   }
 }

--- a/workflow/skills/goat-critique/SKILL.md
+++ b/workflow/skills/goat-critique/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-critique
 description: "Use when a decision or analysis needs multi-lens critique to surface blind spots before shipping."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-critique
 

--- a/workflow/skills/goat-debug/SKILL.md
+++ b/workflow/skills/goat-debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-debug
 description: "Use when diagnosing a bug, unexpected behaviour, or system failure that needs structured investigation."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-debug
 

--- a/workflow/skills/goat-plan/SKILL.md
+++ b/workflow/skills/goat-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-plan
 description: "Use when starting a non-trivial implementation that needs structured task breakdown with progress tracking."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-plan
 

--- a/workflow/skills/goat-qa/SKILL.md
+++ b/workflow/skills/goat-qa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-qa
 description: "Use when evaluating test coverage gaps, planning test strategy, or assessing testing risk for code changes."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-qa
 

--- a/workflow/skills/goat-review/SKILL.md
+++ b/workflow/skills/goat-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-review
 description: "Use when reviewing a diff, PR, or set of code changes, or auditing a codebase area for quality issues. Triggers: 'review this', 'code review', 'audit X', 'look at these changes'."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-review
 

--- a/workflow/skills/goat-security/SKILL.md
+++ b/workflow/skills/goat-security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat-security
 description: "Use when assessing security implications of code changes, architecture decisions, or new features."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat-security
 

--- a/workflow/skills/goat/SKILL.md
+++ b/workflow/skills/goat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: goat
 description: "Use when you describe an outcome and need the right goat-* workflow chosen for you."
-goat-flow-skill-version: "1.2.4"
+goat-flow-skill-version: "1.2.5"
 ---
 # /goat
 

--- a/workflow/skills/reference/skill-quality-testing/deployment.md
+++ b/workflow/skills/reference/skill-quality-testing/deployment.md
@@ -37,7 +37,7 @@ Every skill MUST pass this checklist before merging. Track each item as a todo i
 
 **GREEN phase - write minimal skill:**
 - [ ] Name describes what you DO or the core insight
-- [ ] Frontmatter has `goat-flow-skill-version: "1.2.4"` and trigger-only `description`
+- [ ] Frontmatter has `goat-flow-skill-version: "1.2.5"` and trigger-only `description`
 - [ ] `description` is CSO-optimised: "Use when [trigger]", not a workflow summary
 - [ ] Keywords throughout for search (error messages, symptoms, tool names)
 - [ ] Overview states the core principle in 1–2 sentences


### PR DESCRIPTION
This pull request addresses a critical bug in the CLI entry-point guard that caused the CLI to silently fail when invoked via an npm symlink (the standard usage path), and adds robust regression tests and documentation to prevent similar issues. The main changes fix the guard logic to correctly detect main-module execution even when launched through a symlink, add integration tests for this scenario, and document the root cause and prevention steps for future maintainers.

**CLI entry-point guard fix:**

* Refactored the main-module guard in `src/cli/cli.ts` to use `realpathSync()` on both `process.argv[1]` and `import.meta.url`, ensuring correct behavior when the CLI is invoked through a symlink (the default npm/npx path). Introduced a new `isMainModule()` function for clarity and reliability. [[1]](diffhunk://#diff-25768f5853544984f9e0188641fe6d70f0e5d5245c9317d80be7d3d32a71dd44L11-R11) [[2]](diffhunk://#diff-25768f5853544984f9e0188641fe6d70f0e5d5245c9317d80be7d3d32a71dd44L804-R819)

**Testing improvements:**

* Added a new integration test `test/integration/main-guard.test.ts` that verifies the CLI runs correctly when launched both via a symlink (mimicking npm-installed usage) and via the real path, preventing future regressions of this class.

**Documentation and lessons learned:**

* Added a detailed footgun entry in `.goat-flow/footguns/cli.md` explaining why the previous guard failed, symptoms, evidence, and prevention strategies.
* Added a lesson in `.goat-flow/lessons/verification.md` highlighting the importance of testing the published invocation path, not just direct execution, to catch issues like this in the future.